### PR TITLE
Rename Authentication class to Oauth1

### DIFF
--- a/client.php
+++ b/client.php
@@ -33,4 +33,4 @@ function autoload( $class ) {
 }
 
 spl_autoload_register( __NAMESPACE__ . '\\autoload' );
-WP_CLI::add_command( 'api authentication', __NAMESPACE__ . '\\Commands\\Authentication' );
+WP_CLI::add_command( 'api oauth1', __NAMESPACE__ . '\\Commands\\OAuth1' );

--- a/lib/commands/oauth1.php
+++ b/lib/commands/oauth1.php
@@ -13,7 +13,7 @@ use WP_CLI;
 use WP_CLI_Command;
 use WP_JSON\CLI\Locator;
 
-class Authentication extends WP_CLI_Command {
+class OAuth1 extends WP_CLI_Command {
 	/**
 	 * ## OPTIONS
 	 *


### PR DESCRIPTION
It better communicates what the class is for, and allows for other
authentication mechanisms
