### PR TITLE
Cache authentication between requests

### DIFF
--- a/lib/authenticator.php
+++ b/lib/authenticator.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace WP_JSON\CLI;
+
+use Exception;
+use Requests_Auth_OAuth1;
+use WP_CLI;
+
+class Authenticator {
+	public static function get_for_site( $url ) {
+		$cache = WP_CLI::get_cache();
+		$cache_key = 'api/oauth1-' . sha1( $url );
+		if ( ! $cache->has( $cache_key, 0 ) ) {
+			return null;
+		}
+
+		$contents = $cache->read( $cache_key, 0 );
+		if ( empty( $contents ) ) {
+			return null;
+		}
+		return unserialize( $contents );
+	}
+
+	public static function save_for_site( $url, Requests_Auth_OAuth1 $auth ) {
+		$cache = WP_CLI::get_cache();
+		$cache_key = 'api/oauth1-' . sha1( $url );
+		$contents = serialize( $auth );
+		return $cache->write( $cache_key, $contents );
+	}
+
+	public static function delete_for_site( $url ) {
+		$cache = WP_CLI::get_cache();
+		$cache_key = 'api/oauth1-' . sha1( $url );
+		if ( ! $cache->has( $cache_key, 0 ) ) {
+			return false;
+		}
+
+		return $cache->remove( $cache_key );
+	}
+}

--- a/lib/commands/oauth1.php
+++ b/lib/commands/oauth1.php
@@ -109,9 +109,27 @@ class OAuth1 extends WP_CLI_Command {
 	}
 
 	/**
+	 * ## OPTIONS
+	 *
+	 * <url>
+	 * : URL for the WordPress site
+	 *
 	 * @when before_wp_load
 	 */
-	public function disconnect() {
-		// ...
+	public function disconnect( $args ) {
+		try {
+			// Find the API
+			$locator = new Locator();
+			$url = $locator->locate( $args[0] );
+			if ( ! Authenticator::delete_for_site( $url ) ) {
+				WP_CLI::error( "Could not disconnect client" );
+			}
+			else {
+				WP_CLI::success( sprintf( 'Disconnected from %s', $url ) );
+			}
+		}
+		catch ( Exception $e ) {
+			WP_CLI::error( $e->getMessage() );
+		}
 	}
 }

--- a/lib/commands/oauth1.php
+++ b/lib/commands/oauth1.php
@@ -11,6 +11,7 @@ use Requests_Auth_OAuth1;
 use Requests_Session;
 use WP_CLI;
 use WP_CLI_Command;
+use WP_JSON\CLI\Authenticator;
 use WP_JSON\CLI\Locator;
 
 class OAuth1 extends WP_CLI_Command {
@@ -28,6 +29,9 @@ class OAuth1 extends WP_CLI_Command {
 	 *
 	 * [--scope=<scope>]
 	 * : Scopes to request
+	 *
+	 * [--no-cache]
+	 * : Don't save key/secret into authentication cache
 	 *
 	 * @when before_wp_load
 	 */
@@ -90,6 +94,10 @@ class OAuth1 extends WP_CLI_Command {
 
 			$token = new OAuthToken( $token_args['oauth_token'], $token_args['oauth_token_secret'] );
 			$auth->set_token( $token );
+
+			if ( empty( $assoc_args['no-cache'] ) ) {
+				Authenticator::save_for_site( $url, $auth );
+			}
 
 			WP_CLI::line( "Authorized!" );
 			WP_CLI::line( sprintf( "Key: %s", $token_args['oauth_token'] ) );

--- a/lib/commands/oauth1.php
+++ b/lib/commands/oauth1.php
@@ -116,6 +116,35 @@ class OAuth1 extends WP_CLI_Command {
 	 *
 	 * @when before_wp_load
 	 */
+	public function status( $args ) {
+		$locator = new Locator();
+		try {
+			$url = $locator->locate( $args[0] );
+			$auth = Authenticator::get_for_site( $url );
+			if ( empty( $auth ) ) {
+				WP_CLI::error( sprintf( 'No authentication found for %s', $url ) );
+			}
+
+			$token = $auth->get_token();
+			$consumer = $auth->get_consumer();
+			WP_CLI::line( sprintf( 'Consumer key: %s', $consumer->key ) );
+			WP_CLI::line( sprintf( 'Consumer secret: %s', $consumer->secret ) );
+			WP_CLI::line( sprintf( 'Token key: %s', $token->key ) );
+			WP_CLI::line( sprintf( 'Token secret: %s', $token->secret ) );
+		}
+		catch ( Exception $e ) {
+			WP_CLI::error( $e->getMessage() );
+		}
+	}
+
+	/**
+	 * ## OPTIONS
+	 *
+	 * <url>
+	 * : URL for the WordPress site
+	 *
+	 * @when before_wp_load
+	 */
 	public function disconnect( $args ) {
 		try {
 			// Find the API

--- a/requestsoauth/requests.php
+++ b/requestsoauth/requests.php
@@ -20,8 +20,16 @@ class Requests_Auth_OAuth1 implements Requests_Auth {
 		}
 	}
 
+	public function get_token() {
+		return $this->token;
+	}
+
 	public function set_token(OAuthToken $token = null) {
 		$this->token = $token;
+	}
+
+	public function get_consumer() {
+		return $this->consumer;
 	}
 
 	public function register(Requests_Hooks &$hooks) {


### PR DESCRIPTION
Requires connecting first, then caches access token indefinitely for use.

Fixes #2.
