### PR TITLE
Send correct data when using OAuth

### DIFF
--- a/requestsoauth/requests.php
+++ b/requestsoauth/requests.php
@@ -50,6 +50,7 @@ class Requests_Auth_OAuth1 implements Requests_Auth {
 	public function get_request_token( $session, $path = '', $callback = 'oob' ) {
 		$request_session = clone $session;
 		$response = $request_session->post( $path );
+		$response->throw_for_status();
 
 		return $response;
 	}
@@ -57,6 +58,7 @@ class Requests_Auth_OAuth1 implements Requests_Auth {
 	public function get_access_token( $session, $path = '', $verifier = '' ) {
 		$request_session = clone $session;
 		$response = $request_session->post( $path, array(), array( 'oauth_verifier' => $verifier ) );
+		$response->throw_for_status();
 
 		return $response;
 	}

--- a/requestsoauth/requests.php
+++ b/requestsoauth/requests.php
@@ -37,7 +37,7 @@ class Requests_Auth_OAuth1 implements Requests_Auth {
 	}
 
 	public function add_headers(&$url, &$headers, &$data, &$type, &$options) {
-		$request = OAuthRequest::from_consumer_and_token($this->consumer, $this->token, $type, $url, $data);
+		$request = OAuthRequest::from_consumer_and_token($this->consumer, $this->token, $options['type'], $url, $data);
 		$request->sign_request($this->signature_method, $this->consumer, $this->token);
 
 		$headers['Authorization'] = $request->to_header();

--- a/requestsoauth/requests.php
+++ b/requestsoauth/requests.php
@@ -40,7 +40,11 @@ class Requests_Auth_OAuth1 implements Requests_Auth {
 		$request = OAuthRequest::from_consumer_and_token($this->consumer, $this->token, $options['type'], $url, $data);
 		$request->sign_request($this->signature_method, $this->consumer, $this->token);
 
-		$headers['Authorization'] = $request->to_header();
+		$header = $request->to_header();
+
+		// Strip leading 'Authorization:'
+		$header = trim( substr( $header, 14 ) );
+		$headers['Authorization'] = trim( $header, ' ' );
 	}
 
 	public function get_request_token( $session, $path = '', $callback = 'oob' ) {


### PR DESCRIPTION
Currently, this is slightly broken, which causes strange, transient problems. This is because the internal format of Requests' data is slightly different to what we're expecting, plus we're sending a header incorrectly.
